### PR TITLE
Add union based query builder for incremental snapshots [EH-1017]

### DIFF
--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresSignalBasedIncrementalSnapshotChangeEventSource.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresSignalBasedIncrementalSnapshotChangeEventSource.java
@@ -5,7 +5,17 @@
  */
 package io.debezium.connector.postgresql;
 
+import static io.debezium.connector.postgresql.PostgresConnectorConfig.IncrementalSnapshotChunkQueryBuilderType.SIMPLE;
+import static io.debezium.connector.postgresql.PostgresConnectorConfig.IncrementalSnapshotChunkQueryBuilderType.UNION_BASED;
+
+import java.sql.PreparedStatement;
 import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.OptionalLong;
+import java.util.stream.Collectors;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -18,7 +28,7 @@ import io.debezium.pipeline.source.snapshot.incremental.SignalBasedIncrementalSn
 import io.debezium.pipeline.source.spi.DataChangeEventListener;
 import io.debezium.pipeline.source.spi.SnapshotProgressListener;
 import io.debezium.pipeline.spi.OffsetContext;
-import io.debezium.relational.RelationalDatabaseConnectorConfig;
+import io.debezium.relational.Column;
 import io.debezium.relational.Table;
 import io.debezium.relational.TableId;
 import io.debezium.schema.DatabaseSchema;
@@ -37,8 +47,9 @@ public class PostgresSignalBasedIncrementalSnapshotChangeEventSource
 
     private final PostgresConnection jdbcConnection;
     private final PostgresSchema schema;
+    private final PostgresConnectorConfig.IncrementalSnapshotChunkQueryBuilderType queryBuilderType;
 
-    public PostgresSignalBasedIncrementalSnapshotChangeEventSource(RelationalDatabaseConnectorConfig config,
+    public PostgresSignalBasedIncrementalSnapshotChangeEventSource(PostgresConnectorConfig config,
                                                                    JdbcConnection jdbcConnection,
                                                                    EventDispatcher<PostgresPartition, TableId> dispatcher,
                                                                    DatabaseSchema<?> databaseSchema,
@@ -49,6 +60,7 @@ public class PostgresSignalBasedIncrementalSnapshotChangeEventSource
         super(config, jdbcConnection, dispatcher, databaseSchema, clock, progressListener, dataChangeEventListener, notificationService);
         this.jdbcConnection = (PostgresConnection) jdbcConnection;
         this.schema = (PostgresSchema) databaseSchema;
+        this.queryBuilderType = config.getIncrementalSnapshotQueryBuilderType();
     }
 
     @Override
@@ -57,4 +69,129 @@ public class PostgresSignalBasedIncrementalSnapshotChangeEventSource
         schema.refresh(jdbcConnection, table.id(), true);
         return schema.tableFor(table.id());
     }
+
+    @Override
+    protected String buildChunkQuery(Table table, int limit, Optional<String> additionalCondition) {
+        // Select query builder based on the configuration only on PostgreSQL Connector (incremental.snapshot.query.builder.type)
+        if (queryBuilderType == UNION_BASED) {
+            return buildUnionBasedChunkQuery(table, limit, additionalCondition);
+        }
+
+        return super.buildChunkQuery(table, limit, additionalCondition);
+    }
+
+    @Override
+    protected PreparedStatement readTableChunkStatement(String sql) throws SQLException {
+        if (queryBuilderType == SIMPLE) {
+            return super.readTableChunkStatement(sql);
+        }
+
+        final PreparedStatement statement = jdbcConnection.readTablePreparedStatement(connectorConfig, sql,
+                OptionalLong.empty());
+        if (context.isNonInitialChunk()) {
+            final Object[] maximumKey = context.maximumKey().get();
+            final Object[] chunkEndPosition = context.chunkEndPosititon();
+            // Fill boundaries placeholders
+            int pos = 0;
+            final List<Column> queryColumns = getQueryColumns(getCurrentTable());
+
+            // Loop over each boundary condition
+            for (int i = 0; i < chunkEndPosition.length; i++) {
+                // Fill lower bound placeholders for each column
+                for (int j = 0; j < i + 1; j++) {
+                    jdbcConnection.setQueryColumnValue(statement, queryColumns.get(j), ++pos, chunkEndPosition[j]);
+                }
+                // Fill upper bound placeholders for each column
+                for (int j = 0; j < i + 1; j++) {
+                    jdbcConnection.setQueryColumnValue(statement, queryColumns.get(j), ++pos, maximumKey[j]);
+                }
+            }
+        }
+        return statement;
+    }
+
+    private String buildUnionBasedChunkQuery(Table table, int limit, Optional<String> additionalCondition) {
+        List<String> boundConditions = Collections.emptyList();
+
+        // Add condition when this is not the first query
+        if (context.isNonInitialChunk()) {
+            // Window boundaries
+            boundConditions = getBoundConditions(table);
+        }
+
+        List<String> orderByColumnNames = getQueryColumns(table).stream()
+                .map(Column::name)
+                .collect(Collectors.toList());
+
+        return jdbcConnection.buildUnionBasedSelectWithRowLimits(table.id(),
+                limit,
+                buildProjection(table),
+                boundConditions,
+                additionalCondition,
+                orderByColumnNames);
+    }
+
+    private List<String> getBoundConditions(Table table) {
+        // Provides boundary conditions for the incremental snapshot query
+        // For one column the condition will be (? will always be the last value seen for the given column)
+        // (k1 > ?) AND (k1 <= ?)
+        // For two columns
+        // (k1 > ?) AND (k1 <= ?)
+        // (k1 = ? AND k2 > ?) AND (k1 <> ? OR k2 <= ?)
+        // For three columns
+        // (k1 > ?) AND (k1 <= ?)
+        // (k1 = ? AND k2 > ?) AND (k1 <> ? OR k2 <= ?)
+        // (k1 >= ? AND k2 >= ? AND k3 > ?) AND (k1 <> ? OR k2 <> ? OR k3 <= ?)
+        // For four columns
+        // (k1 > ?) AND (k1 <= ?)
+        // (k1 = ? AND k2 > ?) AND (k1 <> ? OR k2 <= ?)
+        // (k1 >= ? AND k2 >= ? AND k3 > ?) AND (k1 <> ? OR k2 <> ? OR k3 <= ?)
+        // (k1 = ? AND k2 = ? AND k3 = ? AND k4 > ?) AND (k1 <> ? OR k2 <> ? OR k3 <> ? OR k4 <= ?)
+        // etc.
+        List<String> conditionList = new ArrayList<>();
+        final List<Column> pkColumns = getQueryColumns(table);
+
+        for (int i = 0; i < pkColumns.size(); i++) {
+            StringBuilder sql = new StringBuilder("(");
+
+            for (int j = 0; j < i + 1; j++) {
+                final boolean isLastIterationForJ = (i == j);
+
+                sql.append(jdbcConnection.quotedColumnIdString(pkColumns.get(j).name()));
+                sql.append(isLastIterationForJ ? " > ?" : " = ?");
+
+                if (!isLastIterationForJ) {
+                    sql.append(" AND ");
+                }
+            }
+
+            sql.append(") AND (");
+
+            for (int j = 0; j < i + 1; j++) {
+                final boolean isLastIterationForJ = (i == j);
+
+                sql.append(jdbcConnection.quotedColumnIdString(pkColumns.get(j).name()));
+                sql.append(isLastIterationForJ ? " <= ?" : " <> ?");
+
+                if (!isLastIterationForJ) {
+                    sql.append(" OR ");
+                }
+            }
+
+            sql.append(")");
+            conditionList.add(sql.toString());
+        }
+
+        return conditionList;
+    }
+
+    private Table getCurrentTable() {
+        final TableId currentTableId = context.currentDataCollectionId().getId();
+        final Table cTable = schema.tableFor(currentTableId);
+        if (cTable == null) {
+            throw new IllegalStateException("Table " + currentTableId + " not found in schema");
+        }
+        return cTable;
+    }
+
 }

--- a/debezium-connector-postgres/src/test/java/io/debezium/pipeline/source/snapshot/incremental/PostgresSignalBasedSnapshotChangeEventSourceTest.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/pipeline/source/snapshot/incremental/PostgresSignalBasedSnapshotChangeEventSourceTest.java
@@ -1,0 +1,190 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.pipeline.source.snapshot.incremental;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.Test;
+
+import io.debezium.config.Configuration;
+import io.debezium.connector.postgresql.PostgresConnectorConfig;
+import io.debezium.connector.postgresql.PostgresSignalBasedIncrementalSnapshotChangeEventSource;
+import io.debezium.connector.postgresql.connection.PostgresConnection;
+import io.debezium.pipeline.source.spi.DataChangeEventListener;
+import io.debezium.pipeline.source.spi.SnapshotProgressListener;
+import io.debezium.relational.Column;
+import io.debezium.relational.RelationalDatabaseConnectorConfig;
+import io.debezium.relational.Table;
+import io.debezium.relational.TableId;
+
+public class PostgresSignalBasedSnapshotChangeEventSourceTest {
+
+    public static final String CONNECTION_TEST = "Debezium Test";
+
+    protected PostgresConnectorConfig config() {
+        return new PostgresConnectorConfig(Configuration.create()
+                .with(RelationalDatabaseConnectorConfig.SIGNAL_DATA_COLLECTION, "debezium.signal")
+                .with(RelationalDatabaseConnectorConfig.TOPIC_PREFIX, "core")
+                .with(PostgresConnectorConfig.INCREMENTAL_SNAPSHOT_CHUNK_QUERY_BUILDER_TYPE, "union_based")
+                .build());
+    }
+
+    @Test
+    public void testBuildUnionQueryOnePkColumn() {
+        final PostgresSignalBasedIncrementalSnapshotChangeEventSource source = new PostgresSignalBasedIncrementalSnapshotChangeEventSource(
+                config(), new PostgresConnection(config().getJdbcConfig(), CONNECTION_TEST), null, null, null, SnapshotProgressListener.NO_OP(),
+                DataChangeEventListener.NO_OP(), null);
+        final IncrementalSnapshotContext<TableId> context = new SignalBasedIncrementalSnapshotContext<>();
+        source.setContext(context);
+        final Column pk1 = Column.editor().name("pk1").create();
+        final Column val1 = Column.editor().name("val1").create();
+        final Column val2 = Column.editor().name("val2").create();
+        final Table table = Table.editor().tableId(new TableId(null, "s1", "table1"))
+                .addColumn(pk1)
+                .addColumn(val1)
+                .addColumn(val2)
+                .setPrimaryKeyNames("pk1").create();
+        assertThat(source.buildChunkQuery(table, Optional.empty())).isEqualTo("SELECT * FROM \"s1\".\"table1\" ORDER BY \"pk1\" LIMIT 1024");
+        context.nextChunkPosition(new Object[]{ 1, 5 });
+        context.maximumKey(new Object[]{ 10, 50 });
+        assertThat(source.buildChunkQuery(table, Optional.empty())).isEqualTo(
+                "SELECT * FROM \"s1\".\"table1\" WHERE (\"pk1\" > ?) AND (\"pk1\" <= ?) ORDER BY \"pk1\" LIMIT 1024");
+    }
+
+    @Test
+    public void testBuildUnionQueryOnePkColumnWithAdditionalCondition() {
+        final PostgresSignalBasedIncrementalSnapshotChangeEventSource source = new PostgresSignalBasedIncrementalSnapshotChangeEventSource(
+                config(), new PostgresConnection(config().getJdbcConfig(), CONNECTION_TEST), null, null, null, SnapshotProgressListener.NO_OP(),
+                DataChangeEventListener.NO_OP(), null);
+        final IncrementalSnapshotContext<TableId> context = new SignalBasedIncrementalSnapshotContext<>();
+        source.setContext(context);
+        final Column pk1 = Column.editor().name("pk1").create();
+        final Column val1 = Column.editor().name("val1").create();
+        final Column val2 = Column.editor().name("val2").create();
+        final Table table = Table.editor().tableId(new TableId(null, "s1", "table1"))
+                .addColumn(pk1)
+                .addColumn(val1)
+                .addColumn(val2)
+                .setPrimaryKeyNames("pk1").create();
+        assertThat(source.buildChunkQuery(table, Optional.of("\"val1\"=foo")))
+                .isEqualTo("SELECT * FROM \"s1\".\"table1\" WHERE \"val1\"=foo ORDER BY \"pk1\" LIMIT 1024");
+        context.nextChunkPosition(new Object[]{ 1, 5 });
+        context.maximumKey(new Object[]{ 10, 50 });
+        assertThat(source.buildChunkQuery(table, Optional.of("\"val1\"=foo"))).isEqualTo(
+                "SELECT * FROM \"s1\".\"table1\" WHERE (\"pk1\" > ?) AND (\"pk1\" <= ?) AND \"val1\"=foo ORDER BY \"pk1\" LIMIT 1024");
+    }
+
+    @Test
+    public void testBuildUnionQueryTwoPkColumnsWithAdditionalConditionWithSurrogateKey() {
+        final PostgresSignalBasedIncrementalSnapshotChangeEventSource source = new PostgresSignalBasedIncrementalSnapshotChangeEventSource(
+                config(), new PostgresConnection(config().getJdbcConfig(), CONNECTION_TEST), null, null, null, SnapshotProgressListener.NO_OP(),
+                DataChangeEventListener.NO_OP(), null);
+        final IncrementalSnapshotContext<TableId> context = new SignalBasedIncrementalSnapshotContext<>();
+        source.setContext(context);
+        final Column pk1 = Column.editor().name("pk1").create();
+        final Column pk2 = Column.editor().name("pk2").create();
+        final Column val1 = Column.editor().name("val1").create();
+        final Column val2 = Column.editor().name("val2").create();
+        final Table table = Table.editor().tableId(new TableId(null, "s1", "table1"))
+                .addColumn(pk1)
+                .addColumn(pk2)
+                .addColumn(val1)
+                .addColumn(val2)
+                .setPrimaryKeyNames("pk1", "pk2").create();
+        context.addDataCollectionNamesToSnapshot("12345", List.of(table.id().toString()), List.of(), "pk2");
+        assertThat(source.buildChunkQuery(table, Optional.of("\"val1\"=foo")))
+                .isEqualTo("SELECT * FROM \"s1\".\"table1\" WHERE \"val1\"=foo ORDER BY \"pk2\" LIMIT 1024");
+        context.nextChunkPosition(new Object[]{ 1, 5 });
+        context.maximumKey(new Object[]{ 10, 50 });
+        assertThat(source.buildChunkQuery(table, Optional.of("\"val1\"=foo"))).isEqualTo(
+                "SELECT * FROM \"s1\".\"table1\" WHERE (\"pk2\" > ?) AND (\"pk2\" <= ?) AND \"val1\"=foo ORDER BY \"pk2\" LIMIT 1024");
+    }
+
+    @Test
+    public void testBuildUnionQueryThreePkColumns() {
+        final PostgresSignalBasedIncrementalSnapshotChangeEventSource source = new PostgresSignalBasedIncrementalSnapshotChangeEventSource(
+                config(), new PostgresConnection(config().getJdbcConfig(), CONNECTION_TEST), null, null, null, SnapshotProgressListener.NO_OP(),
+                DataChangeEventListener.NO_OP(), null);
+        final IncrementalSnapshotContext<TableId> context = new SignalBasedIncrementalSnapshotContext<>();
+        source.setContext(context);
+        final Column pk1 = Column.editor().name("pk1").create();
+        final Column pk2 = Column.editor().name("pk2").create();
+        final Column pk3 = Column.editor().name("pk3").create();
+        final Column val1 = Column.editor().name("val1").create();
+        final Column val2 = Column.editor().name("val2").create();
+        final Table table = Table.editor().tableId(new TableId(null, "s1", "table1"))
+                .addColumn(pk1)
+                .addColumn(pk2)
+                .addColumn(pk3)
+                .addColumn(val1)
+                .addColumn(val2)
+                .setPrimaryKeyNames("pk1", "pk2", "pk3").create();
+        assertThat(source.buildChunkQuery(table, Optional.empty()))
+                .isEqualTo("SELECT * FROM \"s1\".\"table1\" ORDER BY \"pk1\", \"pk2\", \"pk3\" LIMIT 1024");
+        context.nextChunkPosition(new Object[]{ 1, 5 });
+        context.nextChunkPosition(new Object[]{ 1, 5 });
+        context.maximumKey(new Object[]{ 10, 50 });
+        String result = source.buildChunkQuery(table, Optional.empty());
+        assertThat(result).isEqualTo(
+                "SELECT * FROM (" +
+                        "(SELECT * FROM \"s1\".\"table1\" " +
+                        "WHERE (\"pk1\" > ?) AND (\"pk1\" <= ?) " +
+                        "ORDER BY \"pk1\", \"pk2\", \"pk3\" LIMIT 1024) " +
+                        "UNION " +
+                        "(SELECT * FROM \"s1\".\"table1\" " +
+                        "WHERE (\"pk1\" = ? AND \"pk2\" > ?) AND (\"pk1\" <> ? OR \"pk2\" <= ?) " +
+                        "ORDER BY \"pk1\", \"pk2\", \"pk3\" LIMIT 1024) " +
+                        "UNION " +
+                        "(SELECT * FROM \"s1\".\"table1\" " +
+                        "WHERE (\"pk1\" = ? AND \"pk2\" = ? AND \"pk3\" > ?) AND (\"pk1\" <> ? OR \"pk2\" <> ? OR \"pk3\" <= ?) " +
+                        "ORDER BY \"pk1\", \"pk2\", \"pk3\" LIMIT 1024)" +
+                        ") AS t " +
+                        "ORDER BY \"t\".\"pk1\", \"t\".\"pk2\", \"t\".\"pk3\" LIMIT 1024");
+    }
+
+    @Test
+    public void testBuildUnionQueryThreePkColumnsWithAdditionalCondition() {
+        final PostgresSignalBasedIncrementalSnapshotChangeEventSource source = new PostgresSignalBasedIncrementalSnapshotChangeEventSource(
+                config(), new PostgresConnection(config().getJdbcConfig(), CONNECTION_TEST), null, null, null, SnapshotProgressListener.NO_OP(),
+                DataChangeEventListener.NO_OP(), null);
+        final IncrementalSnapshotContext<TableId> context = new SignalBasedIncrementalSnapshotContext<>();
+        source.setContext(context);
+        final Column pk1 = Column.editor().name("pk1").create();
+        final Column pk2 = Column.editor().name("pk2").create();
+        final Column pk3 = Column.editor().name("pk3").create();
+        final Column val1 = Column.editor().name("val1").create();
+        final Column val2 = Column.editor().name("val2").create();
+        final Table table = Table.editor().tableId(new TableId(null, "s1", "table1"))
+                .addColumn(pk1)
+                .addColumn(pk2)
+                .addColumn(pk3)
+                .addColumn(val1)
+                .addColumn(val2)
+                .setPrimaryKeyNames("pk1", "pk2", "pk3").create();
+        assertThat(source.buildChunkQuery(table, Optional.of("\"val1\"=foo")))
+                .isEqualTo("SELECT * FROM \"s1\".\"table1\" WHERE \"val1\"=foo ORDER BY \"pk1\", \"pk2\", \"pk3\" LIMIT 1024");
+        context.nextChunkPosition(new Object[]{ 1, 5 });
+        context.maximumKey(new Object[]{ 10, 50 });
+        assertThat(source.buildChunkQuery(table, Optional.of("\"val1\"=foo"))).isEqualTo(
+                "SELECT * FROM (" +
+                        "(SELECT * FROM \"s1\".\"table1\" " +
+                        "WHERE (\"pk1\" > ?) AND (\"pk1\" <= ?) AND \"val1\"=foo " +
+                        "ORDER BY \"pk1\", \"pk2\", \"pk3\" LIMIT 1024) " +
+                        "UNION " +
+                        "(SELECT * FROM \"s1\".\"table1\" " +
+                        "WHERE (\"pk1\" = ? AND \"pk2\" > ?) AND (\"pk1\" <> ? OR \"pk2\" <= ?) AND \"val1\"=foo " +
+                        "ORDER BY \"pk1\", \"pk2\", \"pk3\" LIMIT 1024) " +
+                        "UNION " +
+                        "(SELECT * FROM \"s1\".\"table1\" " +
+                        "WHERE (\"pk1\" = ? AND \"pk2\" = ? AND \"pk3\" > ?) AND (\"pk1\" <> ? OR \"pk2\" <> ? OR \"pk3\" <= ?) AND \"val1\"=foo " +
+                        "ORDER BY \"pk1\", \"pk2\", \"pk3\" LIMIT 1024)" +
+                        ") AS t " +
+                        "ORDER BY \"t\".\"pk1\", \"t\".\"pk2\", \"t\".\"pk3\" LIMIT 1024");
+    }
+}

--- a/debezium-core/src/main/java/io/debezium/pipeline/source/snapshot/incremental/AbstractIncrementalSnapshotChangeEventSource.java
+++ b/debezium-core/src/main/java/io/debezium/pipeline/source/snapshot/incremental/AbstractIncrementalSnapshotChangeEventSource.java
@@ -806,11 +806,11 @@ public abstract class AbstractIncrementalSnapshotChangeEventSource<P extends Par
         return table;
     }
 
-    private KeyMapper getKeyMapper() {
+    protected KeyMapper getKeyMapper() {
         return connectorConfig.getKeyMapper() == null ? table -> table.primaryKeyColumns() : connectorConfig.getKeyMapper();
     }
 
-    private List<Column> getQueryColumns(Table table) {
+    protected List<Column> getQueryColumns(Table table) {
         if (context != null && context.currentDataCollectionId() != null) {
             Optional<String> surrogateKey = context.currentDataCollectionId().getSurrogateKey();
             if (surrogateKey.isPresent()) {


### PR DESCRIPTION
Union based query builder is a faster alternative to the default Debezium query builder.

It can be activated by setting the following configuration item on Debezium connector config.

`incremental.snapshot.chunk.query.builder.type = union_based`

[EH-1017]

[EH-1017]: https://aiven.atlassian.net/browse/EH-1017?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ